### PR TITLE
Add dark mode and network status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Les fichiers sont désormais séparés :
 La fonction de gestion de dossier local utilise l'API File System Access. Si elle n'est pas disponible, un message s'affiche et l'import de fichiers est désactivé.
 
 Un service worker (`sw.js`) met en cache les ressources principales afin de permettre un affichage basique hors ligne.
+Un commutateur permet d'activer un **mode sombre** et l'état de connexion est affiché.
 
 Pour exécuter les tests unitaires :
 

--- a/events.json
+++ b/events.json
@@ -1,4 +1,7 @@
 [
   {"date": "2024-06-10", "title": "Réserver logement"},
-  {"date": "2024-06-20", "title": "Vaccination"}
+  {"date": "2024-06-20", "title": "Vaccination"},
+  {"date": "2024-07-01", "title": "Dernier jour de travail"},
+  {"date": "2024-08-15", "title": "Acheter assurance"},
+  {"date": "2024-10-30", "title": "Vérification des documents"}
 ]

--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
     <section id="offline">
         <h2>Mode hors-ligne</h2>
         <p>Accès aux informations critiques même sans internet.</p>
+        <div id="network-status"></div>
     </section>
 
     <section id="urgence">
@@ -158,9 +159,9 @@
 
     <section id="parametres">
         <h2>Paramètres</h2>
+        <label><input type="checkbox" id="dark-toggle"> Mode sombre</label>
         <ul>
             <li>Personnalisation des notifications</li>
-            <li>Mode sombre / clair</li>
             <li>Réinitialisation des données</li>
             <li>Import/export de sauvegarde</li>
         </ul>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ async function loadEventsData() {
 }
 let entries = JSON.parse(localStorage.getItem('financeEntries') || '[]');
 let currentBalance = parseFloat(localStorage.getItem('currentBalance') || '0');
+let darkMode = localStorage.getItem('darkMode') === 'true';
 
 async function updateWeather() {
 const city = 'Bangkok';
@@ -156,6 +157,11 @@ document.getElementById("import-files").addEventListener("click", importFiles);
 
 
 document.getElementById('convert-currency').addEventListener('click', convertCurrency);
+document.getElementById('dark-toggle').addEventListener('change', e => {
+    darkMode = e.target.checked;
+    localStorage.setItem('darkMode', darkMode);
+    applyDarkMode();
+});
 document.getElementById('export-note').addEventListener('click', () => {
 const text = document.getElementById('note-text').value;
 const date = new Date().toISOString().slice(0,10);
@@ -167,11 +173,27 @@ a.click();
 URL.revokeObjectURL(a.href);
 });
 
+function applyDarkMode() {
+    document.body.classList.toggle('dark', darkMode);
+    document.getElementById('dark-toggle').checked = darkMode;
+}
+
+function updateNetworkStatus() {
+    const el = document.getElementById('network-status');
+    if (el) el.innerText = navigator.onLine ? 'En ligne' : 'Hors ligne';
+}
+
+window.addEventListener('online', updateNetworkStatus);
+window.addEventListener('offline', updateNetworkStatus);
+
 populateCurrencies();
 updateWeather();
 updateCountdown();
 loadEvents();
 renderFinance();
+applyDarkMode();
+updateNetworkStatus();
+setInterval(updateCountdown, 86400000);
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');
 }

--- a/style.css
+++ b/style.css
@@ -30,3 +30,15 @@ ul {
 table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
 th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
 input, select, button, textarea { margin-top: 0.5rem; }
+
+body.dark {
+    background: #1c1c1c;
+    color: #eee;
+}
+body.dark header {
+    background: #000;
+}
+body.dark section {
+    background: #333;
+    border-color: #555;
+}


### PR DESCRIPTION
## Summary
- enrich events list
- display network status
- add dark mode toggle and styles
- update script to handle theme and connection
- document new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495089f66c8329a62efe9a72ee5c9c