### PR TITLE
Add local server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,8 @@ Pour exécuter les tests unitaires :
 npm test
 ```
 
-Ouvrez `index.html` dans votre navigateur pour visualiser la page.
+Pour lancer le projet en local et activer l'API File System Access, démarrez le serveur puis ouvrez `http://localhost:8000` dans votre navigateur :
+
+```bash
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Ce dépôt contient un exemple de tableau de bord de voyage minimal en HTML.",
   "main": "script.js",
   "scripts": {
-    "test": "node finance.test.js"
+    "test": "node finance.test.js",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,36 @@
+import { createServer } from 'http';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PORT = 8000;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml'
+};
+
+createServer(async (req, res) => {
+  const urlPath = req.url.split('?')[0];
+  const filePath = path.join(__dirname, urlPath === '/' ? 'index.html' : urlPath);
+  try {
+    const data = await fs.readFile(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}).listen(PORT, () => {
+  console.log(`Serveur lancé sur http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create a simple Node static server to serve the page on `localhost`
- expose it through `npm start`
- document local server usage in README

## Testing
- `npm test`
- `node server.js` (checked startup output)

------
https://chatgpt.com/codex/tasks/task_e_68495849a0908329b82faeaf456b6c64