### PR TITLE
Add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Pour lancer le projet en local et activer l'API File System Access, démarrez le
 ```bash
 npm start
 ```
+
+Vous pouvez également lancer le serveur via le script `start.sh` situé à la racine du projet :
+
+```bash
+./start.sh
+```

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Script pour lancer facilement le serveur local
+npm start


### PR DESCRIPTION
## Summary
- add `start.sh` script to simplify starting the server
- document new script usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495ade573083298188b87631cdcbac