### PR TITLE
Improve dashboard and add RSS feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Pour lancer le projet en local et activer l'API File System Access, démarrez le
 npm start
 ```
 
+Pour lancer le serveur et ouvrir automatiquement votre navigateur :
+
+```bash
+npm run open
+```
+
 Vous pouvez également lancer le serveur via le script `start.sh` situé à la racine du projet :
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -30,10 +30,10 @@
 
     <section id="fichiers">
         <h2>Gestion des fichiers</h2>
-        <button id="create-folder">Créer un dossier</button>
-        <button id="choose-dir">Choisir dossier principal</button>
+        <button class="btn" id="create-folder">Créer un dossier</button>
+        <button class="btn" id="choose-dir">Choisir dossier principal</button>
         <input type="file" id="file-input" multiple style="display:none;">
-        <button id="import-files" disabled>Importer des fichiers</button>
+        <button class="btn" id="import-files" disabled>Importer des fichiers</button>
         <div id="file-status"></div>
     </section>
 
@@ -50,7 +50,7 @@
             </label>
             <label>Date <input type="date" id="ticket-date"></label>
             <label>Heure <input type="time" id="ticket-time"></label>
-            <button id="import-ticket">Importer le billet PDF</button>
+            <button class="btn" id="import-ticket">Importer le billet PDF</button>
             <input type="file" id="ticket-file" accept="application/pdf" style="display:none;">
         </div>
         <table id="tickets-table">
@@ -68,7 +68,7 @@
         <div>
             <label>Solde au <input type="date" id="balance-date"></label>
             <input type="number" id="initial-balance" placeholder="Solde initial">
-            <button id="set-balance">Définir</button>
+            <button class="btn" id="set-balance">Définir</button>
         </div>
         <div id="finance-input">
             <h3>Saisie</h3>
@@ -81,7 +81,7 @@
             </label>
             <label>Libellé: <input type="text" id="entry-label"></label>
             <label>Montant: <input type="number" id="entry-amount"></label>
-            <button id="add-entry">Ajouter</button>
+            <button class="btn" id="add-entry">Ajouter</button>
         </div>
         <table id="finance-table">
             <thead>
@@ -96,7 +96,7 @@
             <select id="conv-from"></select>
             <span>→</span>
             <select id="conv-to"></select>
-            <button id="convert-currency">Convertir</button>
+            <button class="btn" id="convert-currency">Convertir</button>
             <div id="conv-result"></div>
         </div>
     </section>
@@ -104,7 +104,7 @@
     <section id="notes">
         <h2>Notes</h2>
         <textarea id="note-text" rows="4" cols="50" placeholder="Votre note..."></textarea><br>
-        <button id="export-note">Exporter la note</button>
+        <button class="btn" id="export-note">Exporter la note</button>
     </section>
 
     <section id="liens">
@@ -117,8 +117,10 @@
         </ul>
     </section>
     <section id="actualites">
-        <h2>Actualités Asie</h2>
-        <p>Flux RSS configurable par l'utilisateur.</p>
+        <h2>Actualités</h2>
+        <input type="url" id="rss-url" placeholder="URL du flux RSS" />
+        <button class="btn" id="load-rss">Charger</button>
+        <ul id="rss-feed"></ul>
     </section>
 
     <section id="agenda">

--- a/open.js
+++ b/open.js
@@ -1,0 +1,20 @@
+import { spawn } from 'child_process';
+import { platform } from 'os';
+
+const server = spawn('node', ['server.js'], { stdio: 'inherit' });
+
+let cmd = '', args = [];
+if (platform() === 'win32') {
+  cmd = 'cmd';
+  args = ['/c', 'start', 'http://localhost:8000'];
+} else if (platform() === 'darwin') {
+  cmd = 'open';
+  args = ['http://localhost:8000'];
+} else {
+  cmd = 'xdg-open';
+  args = ['http://localhost:8000'];
+}
+
+spawn(cmd, args);
+
+server.on('close', code => process.exit(code));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "script.js",
   "scripts": {
     "test": "node finance.test.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "open": "node open.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -254,3 +254,31 @@ setInterval(updateCountdown, 86400000);
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');
 }
+
+function warnIfFileProtocol() {
+    if (location.protocol === 'file:') {
+        alert('L\'application doit être lancée via \"npm start\" ou \"npm run open\" pour utiliser toutes les fonctionnalités.');
+    }
+}
+
+async function loadRSS() {
+    const url = document.getElementById('rss-url').value || 'https://www.lemonde.fr/rss/une.xml';
+    try {
+        const resp = await fetch(url);
+        const text = await resp.text();
+        const doc = new DOMParser().parseFromString(text, 'application/xml');
+        const items = Array.from(doc.querySelectorAll('item')).slice(0, 5);
+        const list = items.map(i => {
+            const title = i.querySelector('title')?.textContent || 'Sans titre';
+            const link = i.querySelector('link')?.textContent || '#';
+            return `<li><a href="${link}" target="_blank">${title}</a></li>`;
+        }).join('');
+        document.getElementById('rss-feed').innerHTML = list || 'Aucun article';
+    } catch (e) {
+        document.getElementById('rss-feed').innerText = 'Impossible de charger le flux';
+    }
+}
+
+document.getElementById('load-rss').addEventListener('click', loadRSS);
+
+warnIfFileProtocol();

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Script pour lancer facilement le serveur local
-npm start
+npm run open

--- a/style.css
+++ b/style.css
@@ -49,8 +49,20 @@ ul {
 table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
 th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
 input, select, button, textarea { margin-top: 0.5rem; }
+.btn {
+    background: #0077cc;
+    color: #fff;
+    border: none;
+    padding: 0.4rem 0.8rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.btn:hover {
+    background: #005fa3;
+}
 .ticket-row td { font-size: 0.9rem; }
 #ticket-form label { display: block; margin-top: 0.5rem; }
+#rss-feed { margin-top: 0.5rem; }
 
 .section-image {
     width: 100%;


### PR DESCRIPTION
## Summary
- add script to launch server and open browser automatically
- style tweaks and button improvements
- allow user-supplied RSS feed and display latest items
- show warning if page opened without server
- document new script in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684962630c2c8329aef94e996995a06c